### PR TITLE
Use slurp for consistent relative path.

### DIFF
--- a/src/config.nim
+++ b/src/config.nim
@@ -4,7 +4,7 @@
 
 import streams, os, types, yaml, utils, unicode
 
-const DefaultConfig = readFile("default_config.yaml")
+const DefaultConfig = slurp(".." / "default_config.yaml")
 
 proc loadEngine(
     shellCmd: ref ShellCmd, config: Config, specificPreset: ConfigPresetEntry


### PR DESCRIPTION
readFile uses compiler's pwd, which is meaningless for embedding data and only coincidentally works in certain cases. It immediately breaks when install gibman with `nimble install repo-url`. slurp/staticRead resolve paths relative to the module they are in.