### PR TITLE
Allow omiting non-essential preset fields

### DIFF
--- a/src/types.nim
+++ b/src/types.nim
@@ -1,6 +1,7 @@
 # Program written by Maxwell Jensen (c) 2025
 # Licensed under European Union Public Licence 1.2.
 # For more information, consult README.md or man page
+import yaml/annotations
 
 type ShellCmd* = object
   engine*: string
@@ -16,11 +17,11 @@ type ConfigIWadEntry* = object
 
 type ConfigPresetEntry* = object
   name*: string
-  description*: string
+  description* {.defaultVal: "".}: string
   engine*: string
   iwad*: string
-  wad*: seq[string]
-  args*: seq[string]
+  wad* {.defaultVal: @[].}: seq[string]
+  args* {.defaultVal: @[].}: seq[string]
 
 type Config* = object
   iwad*: seq[ConfigIWadEntry]


### PR DESCRIPTION
Adding `args: []` to every preset seems kinda redundant.